### PR TITLE
Issue #224 (#238)

### DIFF
--- a/cmd/av/commit_amend.go
+++ b/cmd/av/commit_amend.go
@@ -75,6 +75,9 @@ var commitAmendCmd = &cobra.Command{
 
 		branchesToSync := meta.SubsequentBranches(tx, currentBranchName)
 
+		// Even if it's not configured, there's no need to fetch/push
+		state.Config.NoFetch = true
+		state.Config.NoPush = true
 		err = actions.SyncStack(ctx, repo, client, tx, branchesToSync, state)
 		if err != nil {
 			return err

--- a/internal/reorder/plan.go
+++ b/internal/reorder/plan.go
@@ -29,7 +29,7 @@ func CreatePlan(repo *git.Repo, tx meta.ReadTx, rootBranch string) ([]Cmd, error
 			upstreamCommit = branch.Parent.Head
 		} else {
 			trunkCommit, err := repo.MergeBase(&git.MergeBase{
-				Revs: []string{branchName, branch.Parent.Name},
+				Revs: []string{branchName, "origin/" + branch.Parent.Name},
 			})
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Hi, this issue (#224) is a "good first issue", so I tried to address it

> av commit amend should not fetch or push to remote 

Is my change what this issue aims to address? I'd appreciate clarification of the details if my understanding is incorrect.

Thank you.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
